### PR TITLE
release: 0.5.2-gm3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+[0.5.2-gm3](https://github.com/casey/ord/releases/tag/0.5.2-gm3) - 2023-04-25
+-----------------------------------------------------------------------------
+
+### Added
+- Add `destination-csv` to `ord wallet inscribe` input to allow you to define a list of destinations and filenames when inscribing ordinals.
+
 [0.5.2-gm2](https://github.com/casey/ord/releases/tag/0.5.2-gm2) - 2023-04-21
 -----------------------------------------------------------------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "ord"
-version = "0.5.2-gm2"
+version = "0.5.2-gm3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ord"
 description = "◉ Ordinal wallet and block explorer"
-version = "0.5.2-gm2"
+version = "0.5.2-gm3"
 license = "CC0-1.0"
 edition = "2021"
 autotests = false

--- a/src/subcommand/preview.rs
+++ b/src/subcommand/preview.rs
@@ -93,6 +93,7 @@ impl Preview {
           alignment: None,
           postage: Some(TransactionBuilder::DEFAULT_TARGET_POSTAGE),
           max_inputs: None,
+          destination_csv: None,
         },
       )),
     }

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -105,6 +105,15 @@ impl Inscribe {
     let mut client = options.bitcoin_rpc_client_for_wallet_command(false)?;
 
     if let Some(destination_csv) = self.destination_csv {
+
+      if !self.files.is_empty() {
+        anyhow::anyhow!("Cannot use both --destination-csv and provide files")
+      };
+
+      if !self.destination.is_empty() {
+        anyhow::anyhow!("Cannot use both --destination-csv and --destination")
+      };
+
       let destination_csv_ref = &destination_csv;
       let file = File::open(destination_csv_ref)?;
       let reader = BufReader::new(file);

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -107,12 +107,10 @@ impl Inscribe {
     if let Some(destination_csv) = self.destination_csv {
 
       if !self.files.is_empty() {
-        anyhow::anyhow!("Cannot use both --destination-csv and provide files")
-      };
-
-      if !self.destination.is_empty() {
-        anyhow::anyhow!("Cannot use both --destination-csv and --destination")
-      };
+        return Err(anyhow!("Cannot use both --destination-csv and provide files"));
+      } else if let Some(_) = self.destination {
+        return Err(anyhow!("Cannot use both --destination-csv and --destination"));
+      }
 
       let destination_csv_ref = &destination_csv;
       let file = File::open(destination_csv_ref)?;


### PR DESCRIPTION
- Bump version: 0.5.2-gm2 → 0.5.2-gm3
- Update changelog
- Update `inscribe` command to accept a CSV file of `destination,filename` to allow for multiple destinations in a bulk inscription