### PR TITLE
Add filenames, commit weight, and reveal weights to dump file

### DIFF
--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -32,8 +32,11 @@ pub struct DecodeRawTransactionOutput {
 struct OutputDump {
   satpoint: SatPoint,
   inscriptions: Vec<InscriptionId>,
+  filenames: Vec<PathBuf>,
   commit: String,
+  commit_weight: u64,
   reveals: Vec<String>,
+  reveal_weights: Vec<usize>,
   recovery_descriptors: Vec<String>,
   fees: u64,
 }
@@ -122,6 +125,7 @@ pub(crate) struct Inscribe {
 impl Inscribe {
   pub(crate) fn run(self, options: Options) -> Result {
     let mut inscription = Vec::new();
+    let mut filenames = Vec::new();
     let mut destinations = Vec::new();
 
     let mut client = options.bitcoin_rpc_client_for_wallet_command(false)?;
@@ -153,6 +157,8 @@ impl Inscribe {
         })?;
 
         let file = PathBuf::from(file);
+        filenames.push(file.clone());
+
 
         let i = Inscription::from_file(options.chain(), &file);
         if i.is_ok() {
@@ -171,6 +177,7 @@ impl Inscribe {
     } else {
       for file in self.files.iter() {
         inscription.push(Inscription::from_file(options.chain(), file)?);
+        filenames.push(PathBuf::from(file));
       }
       if self.destination.is_empty() {
         for _ in self.files {
@@ -252,13 +259,13 @@ impl Inscribe {
       .sign_raw_transaction_with_wallet(&unsigned_commit_tx, None, None)?
       .hex;
 
+    let commit_weight = client
+      .call::<DecodeRawTransactionOutput>(
+        "decoderawtransaction",
+        &[signed_raw_commit_tx.raw_hex().into()],
+      )?
+      .weight;
     if !self.no_limit {
-      let commit_weight = client
-        .call::<DecodeRawTransactionOutput>(
-          "decoderawtransaction",
-          &[signed_raw_commit_tx.raw_hex().into()],
-        )?
-        .weight;
       if commit_weight > MAX_STANDARD_TX_WEIGHT.into() {
         bail!(
           "commit transaction weight greater than {MAX_STANDARD_TX_WEIGHT} (MAX_STANDARD_TX_WEIGHT): {commit_weight}"
@@ -305,9 +312,11 @@ impl Inscribe {
         let commit = signed_raw_commit_tx.raw_hex();
 
         let mut reveals = Vec::new();
+        let mut reveal_weights = Vec::new();
         let mut inscriptions = Vec::new();
         for reveal_tx in reveal_txs.iter() {
           reveals.push(reveal_tx.raw_hex());
+          reveal_weights.push(reveal_tx.weight());
           inscriptions.push(reveal_tx.txid().into());
         }
 
@@ -323,8 +332,11 @@ impl Inscribe {
         print_json(OutputDump {
           satpoint,
           inscriptions,
+          filenames,
           commit,
+          commit_weight,
           reveals,
+          reveal_weights,
           recovery_descriptors,
           fees,
         })?;


### PR DESCRIPTION
This PR adds three new keys to the JSON dump file that is generated using `--dump`:

1. A key `filenames` containing an array of the names of all files inscribed, corresponding to the inscription IDs in `inscriptions`.
2. A key `commit_weight` containing the weight of the commit transaction
3. A key `reveal_weights` containing an array of the reveal transaction weights of all reveal transactions, corresponding to the inscription IDs in `inscriptions`.

Having the filenames in the dump allows easily creating a draft collection JSON file from the dump.

Having the commit and reveal weights allows precise estimation of block space requirements and allows to determine if a set of inscriptions can fit within a single block.